### PR TITLE
Hotfix 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This changelog is formatted based on [Keep a Changelog](http://keepachangelog.com/) and this project attempts to adhere to [Semantic Versioning](http://semver.org) as much as possible.
 
+## v2.1.1 - 2018-10-09
+
+### Changed
+
+- Reverted to using normal `DbContext` injection instead of `DbContextPool` to enable lifespan modification.
+- The database context, services and command modules now use transient lifespans. This potentially fixes concurrency errors being thrown by Entity Framework Core.
+
 ## v2.1.0 - 2018-10-08
 
 ### Added

--- a/SchedulerBot.Client/Commands/AdminCommands.cs
+++ b/SchedulerBot.Client/Commands/AdminCommands.cs
@@ -6,6 +6,7 @@ using DSharpPlus.CommandsNext.Attributes;
 namespace SchedulerBot.Client.Commands
 {
     [Hidden, RequireOwner]
+    [ModuleLifespan(ModuleLifespan.Transient)]
     public class AdminCommands : BaseCommandModule
     {
         [Command("admincheck"), Description("Checks if the user is the bot owner.")]

--- a/SchedulerBot.Client/Commands/EventCommands.cs
+++ b/SchedulerBot.Client/Commands/EventCommands.cs
@@ -18,6 +18,7 @@ using SchedulerBot.Data.Services;
 namespace SchedulerBot.Client.Commands
 {
     [Group("event")]
+    [ModuleLifespan(ModuleLifespan.Transient)]
     [Description("Commands for managing events.")]
     public class EventCommands : BaseCommandModule
     {
@@ -308,6 +309,7 @@ namespace SchedulerBot.Client.Commands
         }
 
         [Group("delete")]
+        [ModuleLifespan(ModuleLifespan.Transient)]
         public class DeleteCommands : BaseCommandModule
         {
             private readonly IEventService _eventService;

--- a/SchedulerBot.Client/Commands/HelpCommands.cs
+++ b/SchedulerBot.Client/Commands/HelpCommands.cs
@@ -9,6 +9,7 @@ using SchedulerBot.Client.Builders;
 namespace SchedulerBot.Client.Commands
 {
     [Group("help")]
+    [ModuleLifespan(ModuleLifespan.Transient)]
     public class HelpCommands : BaseCommandModule
     {
         private readonly IConfigurationRoot _configuration;
@@ -163,6 +164,7 @@ namespace SchedulerBot.Client.Commands
         }
 
         [Group("event")]
+        [ModuleLifespan(ModuleLifespan.Transient)]
         public class EventHelpCommands : BaseCommandModule
         {
             [GroupCommand]
@@ -329,6 +331,7 @@ namespace SchedulerBot.Client.Commands
         }
 
         [Group("perms")]
+        [ModuleLifespan(ModuleLifespan.Transient)]
         public class PermissionHelpCommands : BaseCommandModule
         {
             [GroupCommand]
@@ -457,6 +460,7 @@ namespace SchedulerBot.Client.Commands
         }
 
         [Group("settings")]
+        [ModuleLifespan(ModuleLifespan.Transient)]
         public class SettingsHelpCommands : BaseCommandModule
         {
             private readonly IConfigurationRoot _configuration;

--- a/SchedulerBot.Client/Commands/InitializerCommands.cs
+++ b/SchedulerBot.Client/Commands/InitializerCommands.cs
@@ -6,6 +6,7 @@ using SchedulerBot.Data.Services;
 
 namespace SchedulerBot.Client.Commands
 {
+    [ModuleLifespan(ModuleLifespan.Transient)]
     public class InitializerCommands : BaseCommandModule
     {
         private readonly ICalendarService _calendarService;

--- a/SchedulerBot.Client/Commands/MiscCommands.cs
+++ b/SchedulerBot.Client/Commands/MiscCommands.cs
@@ -17,6 +17,7 @@ using SchedulerBot.Data.Services;
 
 namespace SchedulerBot.Client.Commands
 {
+    [ModuleLifespan(ModuleLifespan.Transient)]
     public class MiscCommands : BaseCommandModule
     {
         private readonly ICalendarService _calendarService;

--- a/SchedulerBot.Client/Commands/PermissionsCommands.cs
+++ b/SchedulerBot.Client/Commands/PermissionsCommands.cs
@@ -14,6 +14,7 @@ using SchedulerBot.Data.Services;
 namespace SchedulerBot.Client.Commands
 {
     [Group("perms")] 
+    [ModuleLifespan(ModuleLifespan.Transient)]
     [Description("View and modify permissions for other commands.")]
     public class PermissionsCommands : BaseCommandModule
     {

--- a/SchedulerBot.Client/Commands/SettingsCommands.cs
+++ b/SchedulerBot.Client/Commands/SettingsCommands.cs
@@ -14,6 +14,7 @@ using SchedulerBot.Data.Services;
 namespace SchedulerBot.Client.Commands
 {
     [Group("settings")]
+    [ModuleLifespan(ModuleLifespan.Transient)]
     [Description("Change settings for the bot.")]
     public class SettingsCommands : BaseCommandModule
     {

--- a/SchedulerBot.Client/Program.cs
+++ b/SchedulerBot.Client/Program.cs
@@ -179,16 +179,16 @@ namespace SchedulerBot.Client
 
             // Configure database
             services.AddEntityFrameworkNpgsql()
-                .AddDbContextPool<SchedulerBotContext>(options =>
+                .AddDbContext<SchedulerBotContext>(options =>
                 {
                     options.UseNpgsql(connectionString);
                     options.UseLoggerFactory(loggerFactory);
-                });
+                }, ServiceLifetime.Transient);
 
-            services.AddScoped<ICalendarService, CalendarService>()
-                .AddScoped<IEventService, EventService>()
-                .AddScoped<IPermissionService, PermissionService>()
-                .AddScoped<IShardedClientInformationService, ShardedClientInformationService>(s => new ShardedClientInformationService(Client));
+            services.AddTransient<ICalendarService, CalendarService>()
+                .AddTransient<IEventService, EventService>()
+                .AddTransient<IPermissionService, PermissionService>()
+                .AddTransient<IShardedClientInformationService, ShardedClientInformationService>(s => new ShardedClientInformationService(Client));
                 
             // Scheduler service
             services.AddSingleton<IEventScheduler, EventScheduler>();

--- a/SchedulerBot.Client/SchedulerBot.Client.csproj
+++ b/SchedulerBot.Client/SchedulerBot.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This hotfix changes lifespans of the database context, services and command modules to transient lifespans in an effort to avoid concurrency errors thrown by Entity Framework Core.