### PR TITLE
Fix issue#14 Date and time ranges will throw `KeyNotFoundException`

### DIFF
--- a/SchedulerBot.Client/Parsers/EventParser.cs
+++ b/SchedulerBot.Client/Parsers/EventParser.cs
@@ -292,8 +292,19 @@ namespace SchedulerBot.Client.Parsers
                 {
                     string timex = resolutionValues.First()["timex"].TrimStart('(').TrimEnd(')');
                     string[] timexSplit = timex.Split(',');
-                    string fromString = resolutionValues.First()["start"];
-                    string toString = resolutionValues.First()["end"];
+                    string fromString = "";
+                    string toString = "";
+
+                    try
+                    {
+                        fromString = resolutionValues.First()["start"];
+                        toString = resolutionValues.First()["end"];
+                    }
+                    catch (KeyNotFoundException)
+                    {
+                        throw new EventParseException();
+                    }
+
                     if (timexSplit[0].StartsWith("XXXX-"))
                     {
                         fromString = fromString.Substring(4);
@@ -364,8 +375,19 @@ namespace SchedulerBot.Client.Parsers
                 {
                     var clock = SystemClock.Instance;
                     LocalDate today = clock.InZone(tz).GetCurrentDate();
-                    string fromString = resolutionValues.First()["start"];
-                    string toString = resolutionValues.First()["end"];
+                    string fromString = "";
+                    string toString = "";
+
+                    try
+                    {
+                        fromString = resolutionValues.First()["start"];
+                        toString = resolutionValues.First()["end"];
+                    }
+                    catch (KeyNotFoundException)
+                    {
+                        throw new EventParseException();
+                    }
+
                     string fromDateTimeString = string.Format("{0} {1}", today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), fromString);
                     string toDateTimeString = string.Format("{0} {1}", today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), toString);
 


### PR DESCRIPTION
This pull request fixes Issue https://github.com/pyrox18/SchedulerBot/issues/14.

I just wrapped the code that accesses the `start` and `end` keys of the first resolved value in a try-catch block. If the any of the keys do not exist, then the code will throw `KeyNotFoundException` and then I simply just throw the `EventParseException` because the event date and time cannot be parsed properly.