### PR TITLE
Hotfix 2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog is formatted based on [Keep a Changelog](http://keepachangelog.com/) and this project attempts to adhere to [Semantic Versioning](http://semver.org) as much as possible.
 
+## v2.1.4 - 2018-10-25
+
+### Changed
+
+- Changed the default bot invite link, as the old link did not include permissions to send messages with embeds.
+
 ## v2.1.3 - 2018-10-09
 
 ### Changed

--- a/SchedulerBot.Client/SchedulerBot.Client.csproj
+++ b/SchedulerBot.Client/SchedulerBot.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Version>2.1.3</Version>
+    <Version>2.1.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SchedulerBot.Client/appsettings.json
+++ b/SchedulerBot.Client/appsettings.json
@@ -14,7 +14,7 @@
     "Prefixes": [ "+" ],
     "Status": "+help | v{0}",
     "Links": {
-      "BotInvite": "http://bit.ly/schedulerbot",
+      "BotInvite": "http://bit.ly/schedulerbot-discord",
       "SupportServer": "https://discord.gg/CRxRn5X",
       "TimezoneList": "http://bit.ly/tz-timezones"
     }


### PR DESCRIPTION
Update default bot invite link, as the old link was missing permissions to send embeds.